### PR TITLE
fix: overridden bert_encode() argument does not match

### DIFF
--- a/Pap2Pat/pap2pat/metrics/coherence.py
+++ b/Pap2Pat/pap2pat/metrics/coherence.py
@@ -22,7 +22,7 @@ def load_samples(run_dir: Path, split: str):
         yield (sample_dir.name, gen, ref)
 
 
-def bert_encode_sliding_window(bert, input, am, max_len=512, window_size=256):
+def bert_encode_sliding_window(bert, input, attention_mask, max_len=512, window_size=256):
     """
     Adds sliding window bert encoding to handle long documents
     """
@@ -37,7 +37,7 @@ def bert_encode_sliding_window(bert, input, am, max_len=512, window_size=256):
                 idx = window_size
 
             start = i - max_len
-            out = bert(input_ids = input[:, start:i], token_type_ids = None, attention_mask = am[:, start:i])
+            out = bert(input_ids = input[:, start:i], token_type_ids = None, attention_mask = attention_mask[:, start:i])
             hidden_states.append(out.last_hidden_state[:, idx:, :])
 
         out = torch.cat(hidden_states, dim=1)


### PR DESCRIPTION
When I call `Prediction.compute_coherence()`, I got

```
TypeError: bert_encode_sliding_window() got an unexpected keyword argument 'attention_mask'
```

I'm not sure if it is just me (because I modified `evaluation.py` to adapt to our workflow). But it seems the error is because of the mismatch of the hacked function in `disco_score` package through

```py
disco_score.metrics.sent_graph.bert_encode = bert_encode_sliding_window
```

with its argument `am` not naming `attention_mask`.

Changing the function’s argument name resolves the error on my side.